### PR TITLE
Display preview photo on persons list

### DIFF
--- a/app/models/person.py
+++ b/app/models/person.py
@@ -77,3 +77,5 @@ class PersonStats(BaseModel):
     active_photos: int
     avg_confidence: float
     last_photo_date: Optional[datetime]
+    preview_photo: Optional[str] = None
+

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -7,6 +7,7 @@ import structlog
 
 from app.config.database import get_db
 from app.services.person_service import person_service
+from app.models.person import PersonStats
 
 logger = structlog.get_logger()
 
@@ -91,10 +92,10 @@ async def persons_list_page(
         # Получаем статистику для каждого человека
         persons_with_stats = []
         for person in persons:
-            stats = person_service.get_person_stats(db, person.id)
+            stats_data = person_service.get_person_stats(db, person.id)
             persons_with_stats.append({
                 'person': person,
-                'stats': stats
+                'stats': PersonStats(**stats_data)
             })
 
         return templates.TemplateResponse("persons_list.html", {

--- a/app/services/person_service.py
+++ b/app/services/person_service.py
@@ -321,16 +321,20 @@ class PersonService:
 
             avg_confidence = 0.0
             last_photo_date = None
+            preview_photo = None
 
             if active_photos:
                 avg_confidence = sum(p.confidence for p in active_photos) / active_count
                 last_photo_date = max(p.created_at for p in active_photos)
+                first_photo = min(active_photos, key=lambda p: p.created_at)
+                preview_photo = first_photo.file_path
 
             return {
                 'total_photos': total_photos,
                 'active_photos': active_count,
                 'avg_confidence': avg_confidence,
-                'last_photo_date': last_photo_date
+                'last_photo_date': last_photo_date,
+                'preview_photo': preview_photo
             }
 
         except Exception as e:
@@ -339,7 +343,8 @@ class PersonService:
                 'total_photos': 0,
                 'active_photos': 0,
                 'avg_confidence': 0.0,
-                'last_photo_date': None
+                'last_photo_date': None,
+                'preview_photo': None
             }
 
 

--- a/templates/persons_list.html
+++ b/templates/persons_list.html
@@ -35,10 +35,15 @@
                 <div class="card h-100 shadow-sm">
                     <div class="card-body">
                         <div class="d-flex align-items-center mb-3">
+                            {% if item.stats.preview_photo %}
+                            <img src="/uploads/{{ item.stats.preview_photo }}" alt="{{ item.person.name }}"
+                                 class="rounded-circle me-3" style="width: 50px; height: 50px; object-fit: cover;">
+                            {% else %}
                             <div class="bg-primary rounded-circle d-flex align-items-center justify-content-center me-3"
                                  style="width: 50px; height: 50px;">
                                 <i class="bi bi-person-fill text-white"></i>
                             </div>
+                            {% endif %}
                             <div>
                                 <h5 class="card-title mb-1">{{ item.person.name }}</h5>
                                 <small class="text-muted">ID: {{ item.person.id }}</small>


### PR DESCRIPTION
## Summary
- compute each person's first active photo and expose its path as `preview_photo`
- allow `PersonStats` and the persons list page to use the new `preview_photo` field
- render a preview thumbnail on the persons list, falling back to the placeholder icon when none exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b68568ab083318e3700610293719b