### PR TITLE
Fix database model aliases in system stats endpoint

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -347,7 +347,7 @@ async def health_check(db: Session = Depends(get_db)):
 async def get_system_stats(db: Session = Depends(get_db)):
     """Получить статистику системы"""
     try:
-        from app.models.database import PersonDB, PhotoDB
+        from app.models.database import Person as PersonDB, Photo as PhotoDB
 
         total_persons = db.query(PersonDB).count()
         active_photos = db.query(PhotoDB).filter(PhotoDB.is_active == True).count()


### PR DESCRIPTION
## Summary
- fix import of Person and Photo models in stats endpoint by aliasing to PersonDB and PhotoDB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6dd1f4288331b207ac25fa82ec88