### PR TITLE
feat: add client-side person creation flow

### DIFF
--- a/templates/identify.html
+++ b/templates/identify.html
@@ -299,9 +299,9 @@ document.addEventListener('DOMContentLoaded', function() {
                             </button>
                         </div>
                         <div class="d-flex gap-2">
-                            <a href="/upload" class="btn btn-primary">
+                            <button id="createNewBtn" class="btn btn-primary">
                                 <i class="bi bi-upload me-2"></i>Добавить нового
-                            </a>
+                            </button>
                             <a href="/persons" class="btn btn-outline-secondary">
                                 <i class="bi bi-people me-2"></i>Просмотреть всех
                             </a>
@@ -312,10 +312,53 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const attachBtn = document.getElementById('attachBtn');
             attachBtn.addEventListener('click', attachToPerson);
+            const createNewBtn = document.getElementById('createNewBtn');
+            createNewBtn.addEventListener('click', createNewPerson);
         }
 
         resultsContainer.classList.remove('d-none');
         resultsContainer.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    async function createNewPerson() {
+        const name = prompt('Введите имя нового человека:');
+        if (!name) {
+            return;
+        }
+
+        try {
+            const createResponse = await fetch('/api/persons', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ name: name.trim() })
+            });
+
+            const person = await createResponse.json();
+            if (!createResponse.ok) {
+                throw new Error(person.detail?.error || 'Не удалось создать человека');
+            }
+
+            const formData = new FormData(identifyForm);
+            formData.append('person_id', person.id);
+            formData.append('create_new', 'true');
+
+            const attachResponse = await fetch('/api/identify', {
+                method: 'POST',
+                body: formData
+            });
+
+            const attachResult = await attachResponse.json();
+            if (!attachResponse.ok) {
+                throw new Error(attachResult.detail?.error || 'Не удалось привязать фото');
+            }
+
+            alert('Новый человек успешно создан и фото привязано');
+            window.location.href = `/persons/${person.id}`;
+        } catch (error) {
+            alert('Ошибка: ' + error.message);
+        }
     }
 
     async function attachToPerson() {


### PR DESCRIPTION
## Summary
- allow adding a new person directly from identification results
- attach handler to new button and auto-link uploaded photo to created person

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c4f018c388331a22563089ea1cd0d