### PR TITLE
Propagate face detection errors to API

### DIFF
--- a/templates/identify.html
+++ b/templates/identify.html
@@ -241,7 +241,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const result = await response.json();
 
-            if (response.ok) {
+            if (response.status === 422) {
+                alert('Лицо не найдено');
+            } else if (response.ok) {
                 showResults(result);
             } else {
                 throw new Error(result.detail?.error || 'Ошибка идентификации');


### PR DESCRIPTION
## Summary
- ensure `get_face_embedding` errors raise `FaceDetectionError` instead of generic failure
- show dedicated frontend message when face is missing during identification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c53ae2d4c83318734cb6211d118cf