### PR TITLE
Enable photo deletion from person view

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from pathlib import Path
 import structlog
 
 from app.config.database import get_db
@@ -197,14 +198,15 @@ async def upload_photo(
 
 
 @router.delete("/photos/{photo_id}")
-async def deactivate_photo(photo_id: int, db: Session = Depends(get_db)):
-    """Деактивировать фотографию"""
+async def delete_photo(photo_id: int, db: Session = Depends(get_db)):
+    """Удалить фотографию"""
     try:
-        deactivated = person_service.deactivate_photo(db, photo_id)
-        if not deactivated:
+        file_path = person_service.delete_photo(db, photo_id)
+        if not file_path:
             raise HTTPException(status_code=404, detail="Фотография не найдена")
 
-        return {"message": "Фотография деактивирована"}
+        await file_service.delete_file(str(Path(settings.upload_path) / file_path))
+        return {"message": "Фотография удалена"}
 
     except Exception as e:
         raise await handle_api_error(e)

--- a/app/services/person_service.py
+++ b/app/services/person_service.py
@@ -169,23 +169,24 @@ class PersonService:
             logger.error("Failed to add photo", error=str(e), person_id=person_id)
             raise DatabaseError(f"Не удалось добавить фотографию: {str(e)}")
 
-    def deactivate_photo(self, db: Session, photo_id: int) -> bool:
-        """Деактивировать фотографию"""
+    def delete_photo(self, db: Session, photo_id: int) -> Optional[str]:
+        """Удалить фотографию из базы данных и вернуть путь к файлу"""
         try:
             db_photo = db.query(PhotoDB).filter(PhotoDB.id == photo_id).first()
             if not db_photo:
-                return False
+                return None
 
-            db_photo.is_active = False
+            file_path = db_photo.file_path
+            db.delete(db_photo)
             db.commit()
 
-            logger.info("Photo deactivated", photo_id=photo_id)
-            return True
+            logger.info("Photo deleted", photo_id=photo_id)
+            return file_path
 
         except Exception as e:
             db.rollback()
-            logger.error("Failed to deactivate photo", error=str(e))
-            raise DatabaseError(f"Не удалось деактивировать фотографию: {str(e)}")
+            logger.error("Failed to delete photo", error=str(e))
+            raise DatabaseError(f"Не удалось удалить фотографию: {str(e)}")
 
     def get_all_active_embeddings(self, db: Session) -> List[Dict[str, Any]]:
         """Получить все активные эмбеддинги для поиска"""


### PR DESCRIPTION
## Summary
- support deleting a person's photo via backend and web UI
- remove photo files and database records when deletion is requested

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c57b198648331a34e7d5d7a5449b7