### PR TITLE
Add user authentication and admin management

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,13 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
 import structlog
 from contextlib import asynccontextmanager
 
 from app.config.database import create_tables
 from app.config.settings import settings
 from app.services.face_service import face_service
-from app.routes import api, web
+from app.routes import api, web, auth, admin
 
 # Настройка логирования
 structlog.configure(
@@ -66,9 +67,14 @@ def create_app() -> FastAPI:
         lifespan=lifespan
     )
 
+    # Сессии
+    app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
+
     # Подключение маршрутов
     app.include_router(api.router)
     app.include_router(web.router)
+    app.include_router(auth.router)
+    app.include_router(admin.router)
 
     # Статические файлы
     app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -1,6 +1,16 @@
-from sqlalchemy import Column, Integer, String, Float, Boolean, DateTime, LargeBinary, ForeignKey
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    Boolean,
+    DateTime,
+    LargeBinary,
+    ForeignKey,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from app.config.database import Base
 
 
@@ -31,3 +41,17 @@ class Photo(Base):
 
     # Связь с человеком
     person = relationship("Person", back_populates="photos")
+
+
+class User(Base):
+    """Модель пользователя системы"""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(255), unique=True, nullable=False, index=True)
+    password_hash = Column(String(255), nullable=False)
+    is_admin = Column(Boolean, default=False)
+    is_active = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+from typing import Optional
+
+
+class UserBase(BaseModel):
+    username: str = Field(..., min_length=1, max_length=255)
+
+
+class UserCreate(UserBase):
+    password: str = Field(..., min_length=1, max_length=255)
+
+
+class User(UserBase):
+    id: int
+    is_admin: bool = False
+    is_active: bool = False
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.config.database import get_db
+from app.services.user_service import user_service
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+templates = Jinja2Templates(directory="templates")
+
+
+def require_admin(request: Request):
+    if not request.session.get("user_id"):
+        raise HTTPException(status_code=302, headers={"Location": "/login"})
+    if not request.session.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+
+@router.get("/users", response_class=HTMLResponse)
+async def users_page(request: Request, db: Session = Depends(get_db)):
+    require_admin(request)
+    users = user_service.get_all_users(db)
+    return templates.TemplateResponse(
+        "admin_users.html",
+        {
+            "request": request,
+            "title": "Управление пользователями",
+            "users": users,
+            "page": "admin_users",
+        },
+    )
+
+
+@router.post("/users/{user_id}/approve")
+async def approve_user(
+    request: Request, user_id: int, db: Session = Depends(get_db)
+):
+    require_admin(request)
+    user_service.approve_user(db, user_id)
+    return RedirectResponse("/admin/users", status_code=302)
+
+
+@router.post("/users/{user_id}/delete")
+async def delete_user(
+    request: Request, user_id: int, db: Session = Depends(get_db)
+):
+    require_admin(request)
+    user_service.delete_user(db, user_id)
+    return RedirectResponse("/admin/users", status_code=302)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,98 @@
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.config.database import get_db
+from app.services.user_service import user_service
+
+router = APIRouter(tags=["auth"])
+templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse(
+        "login.html",
+        {"request": request, "title": "Вход", "page": "login"},
+    )
+
+
+@router.post("/login")
+async def login(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    user = user_service.authenticate_user(db, username, password)
+    if not user:
+        return templates.TemplateResponse(
+            "login.html",
+            {
+                "request": request,
+                "title": "Вход",
+                "error": "Неверные данные или пользователь не активирован",
+                "page": "login",
+            },
+            status_code=400,
+        )
+    request.session["user_id"] = user.id
+    request.session["username"] = user.username
+    request.session["is_admin"] = user.is_admin
+    return RedirectResponse("/", status_code=302)
+
+
+@router.get("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/", status_code=302)
+
+
+@router.get("/register", response_class=HTMLResponse)
+async def register_page(request: Request):
+    return templates.TemplateResponse(
+        "register.html",
+        {"request": request, "title": "Регистрация", "page": "register"},
+    )
+
+
+@router.post("/register")
+async def register(
+    request: Request,
+    username: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    existing = user_service.get_user_by_username(db, username)
+    if existing:
+        return templates.TemplateResponse(
+            "register.html",
+            {
+                "request": request,
+                "title": "Регистрация",
+                "error": "Пользователь уже существует",
+                "page": "register",
+            },
+            status_code=400,
+        )
+    is_first = user_service.is_first_user(db)
+    user_service.create_user(
+        db,
+        username,
+        password,
+        is_admin=is_first,
+        is_active=is_first,
+    )
+    message = (
+        "Регистрация успешна. Можете войти." if is_first else "Регистрация прошла. Ожидайте одобрения администратора."
+    )
+    return templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "title": "Вход",
+            "message": message,
+            "page": "login",
+        },
+    )

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,69 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+import hashlib
+
+from app.models.database import User
+
+
+class UserService:
+    """Сервис для работы с пользователями"""
+
+    @staticmethod
+    def _hash_password(password: str) -> str:
+        return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+    def is_first_user(self, db: Session) -> bool:
+        return db.query(User).count() == 0
+
+    def get_user_by_username(self, db: Session, username: str) -> Optional[User]:
+        return db.query(User).filter(User.username == username).first()
+
+    def create_user(
+        self,
+        db: Session,
+        username: str,
+        password: str,
+        *,
+        is_admin: bool = False,
+        is_active: bool = False,
+    ) -> User:
+        user = User(
+            username=username,
+            password_hash=self._hash_password(password),
+            is_admin=is_admin,
+            is_active=is_active,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    def authenticate_user(
+        self, db: Session, username: str, password: str
+    ) -> Optional[User]:
+        user = self.get_user_by_username(db, username)
+        if not user:
+            return None
+        if user.password_hash != self._hash_password(password):
+            return None
+        if not user.is_active:
+            return None
+        return user
+
+    def get_all_users(self, db: Session) -> List[User]:
+        return db.query(User).all()
+
+    def approve_user(self, db: Session, user_id: int) -> None:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user:
+            user.is_active = True
+            db.commit()
+
+    def delete_user(self, db: Session, user_id: int) -> None:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user:
+            db.delete(user)
+            db.commit()
+
+
+user_service = UserService()

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Управление пользователями{% endblock %}
+{% block content %}
+<h2>Пользователи</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Логин</th>
+      <th>Администратор</th>
+      <th>Статус</th>
+      <th>Действия</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for user in users %}
+    <tr>
+      <td>{{ user.username }}</td>
+      <td>{% if user.is_admin %}Да{% else %}Нет{% endif %}</td>
+      <td>{% if user.is_active %}Активен{% else %}Ожидает{% endif %}</td>
+      <td>
+        {% if not user.is_active %}
+        <form method="post" action="/admin/users/{{ user.id }}/approve" class="d-inline">
+          <button class="btn btn-sm btn-success">Одобрить</button>
+        </form>
+        {% endif %}
+        <form method="post" action="/admin/users/{{ user.id }}/delete" class="d-inline" onsubmit="return confirm('Удалить пользователя?');">
+          <button class="btn btn-sm btn-danger">Удалить</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,6 +55,30 @@
                         </a>
                     </li>
                 </ul>
+                <ul class="navbar-nav ms-auto">
+                    {% if request.session.get('user_id') %}
+                        {% if request.session.get('is_admin') %}
+                        <li class="nav-item">
+                            <a class="nav-link {% if page == 'admin_users' %}active{% endif %}" href="/admin/users">
+                                <i class="bi bi-people-fill me-1"></i>Пользователи
+                            </a>
+                        </li>
+                        {% endif %}
+                        <li class="nav-item">
+                            <span class="navbar-text me-2">{{ request.session.get('username') }}</span>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/logout">Выход</a>
+                        </li>
+                    {% else %}
+                        <li class="nav-item">
+                            <a class="nav-link {% if page == 'login' %}active{% endif %}" href="/login">Вход</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if page == 'register' %}active{% endif %}" href="/register">Регистрация</a>
+                        </li>
+                    {% endif %}
+                </ul>
             </div>
         </div>
     </nav>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Вход{% endblock %}
+{% block content %}
+<h2>Вход</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+{% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Логин</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Пароль</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Войти</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Регистрация{% endblock %}
+{% block content %}
+<h2>Регистрация</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Логин</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Пароль</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Зарегистрироваться</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add SQLAlchemy `User` model and service helpers
- implement login, registration, and logout routes
- add admin-only interface for approving or removing users
- integrate session middleware and navigation links for auth

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cadb60ec0833185e133e3a890e841